### PR TITLE
[Mod Suggestion] Adding appleskin

### DIFF
--- a/config/appleskin.cfg
+++ b/config/appleskin.cfg
@@ -1,0 +1,29 @@
+# Configuration file
+
+##########################################################################################################
+# client
+#--------------------------------------------------------------------------------------------------------#
+# These config settings are client-side only
+##########################################################################################################
+
+client {
+    # If true, shows your food exhaustion as a progress bar behind the hunger bars
+    B:show.food.exhaustion.hud.underlay=false
+
+    # If true, adds a line that shows your hunger, saturation, and exhaustion level in the F3 debug overlay
+    B:show.food.stats.in.debug.overlay=true
+
+    # If true, shows the hunger (and saturation if show.saturation.hud.overlay is true) that would be restored by food you are currently holding
+    B:show.food.values.hud.overlay=true
+
+    # If true, shows the hunger and saturation values of food in its tooltip while holding SHIFT
+    B:show.food.values.in.tooltip=false
+
+    # If true, shows the hunger and saturation values of food in its tooltip automatically (without needing to hold SHIFT)
+    B:show.food.values.in.tooltip.always=false
+
+    # If true, shows your current saturation level overlayed on the hunger bar
+    B:show.saturation.hud.overlay=false
+}
+
+

--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -350,7 +350,7 @@ client {
         #  - appleskin
         # This is done to prevent content overlap.
         # You can turn this on to force the feature to be loaded even if the above mods are also loaded.
-        B:"Force Enabled"=false
+        B:"Force Enabled"=true
     }
 
     "map tooltip" {

--- a/minecraftinstance.json
+++ b/minecraftinstance.json
@@ -924,6 +924,84 @@
       "fileCount": 1,
       "fileSize": 843486
     },
+	{
+      "addonID": 248787,
+      "gameInstanceID": "df9ef97a-6a6d-46a7-8151-ba284f164dc9",
+      "installedFile": {
+        "id": 2496585,
+        "displayName": "AppleSkin-mc1.12-1.0.9.jar",
+        "fileName": "AppleSkin-mc1.12-1.0.9.jar",
+        "fileDate": "2017-11-03T00:07:53.083Z",
+        "fileLength": 32317,
+        "releaseType": 1,
+        "fileStatus": 4,
+        "downloadUrl": "https://edge.forgecdn.net/files/2496/585/AppleSkin-mc1.12-1.0.9.jar",
+        "isAlternate": false,
+        "alternateFileId": 0,
+        "dependencies": [],
+        "isAvailable": true,
+        "modules": [
+          {
+            "foldername": "META-INF",
+            "fingerprint": 2464251221,
+            "type": 0
+          },
+          {
+            "foldername": "betterwithmods",
+            "fingerprint": 1637584094,
+            "type": 0
+          },
+          {
+            "foldername": "squeek",
+            "fingerprint": 1048292493,
+            "type": 0
+          },
+          {
+            "foldername": "assets",
+            "fingerprint": 3447702788,
+            "type": 0
+          },
+          {
+            "foldername": "mcmod.info",
+            "fingerprint": 4000864019,
+            "type": 0
+          },
+          {
+            "foldername": "pack.mcmeta",
+            "fingerprint": 2520837536,
+            "type": 0
+          }
+        ],
+        "packageFingerprint": 1708065614,
+        "gameVersion": [
+          "1.12",
+          "1.12.1",
+          "1.12.2"
+        ],
+        "hasInstallScript": false,
+        "isCompatibleWithClient": false,
+        "categorySectionPackageType": 0,
+        "restrictProjectFileAccess": 0,
+        "projectStatus": 0,
+        "projectId": 0,
+        "gameVersionDateReleased": "2017-06-07T05:00:00Z",
+        "gameId": 0,
+        "FileNameOnDisk": "AppleSkin-mc1.12-1.0.9.jar"
+      },
+      "dateInstalled": "2019-07-12T13:03:58.2181026Z",
+      "dateUpdated": "2019-07-12T13:03:58.2231011Z",
+      "dateLastUpdateAttempted": "2019-07-12T13:03:58.2231011Z",
+      "status": 4,
+      "preferenceAutoInstallUpdates": false,
+      "preferenceAlternateFile": false,
+      "preferenceIsIgnored": false,
+      "isModified": false,
+      "isWorkingCopy": false,
+      "isFuzzyMatch": false,
+      "preferenceReleaseType": null,
+      "manifestName": null,
+      "installedTargets": []
+    },
     {
       "folderName": "trapexpansion-1.0.0.jar",
       "fingerprint": 4204679312,


### PR DESCRIPTION
A small suggestion to add Appleskin.
With the included edited settings, it will only show handheld food how many (partial) drumsticks it fills.
Neither saturation nor exhaustion will be shown, and Quark's food tooltip is force enabled.
I also left the debug setting on for those interested.